### PR TITLE
Print the descriptions in the tables and improve the overall rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,12 +5,12 @@ module.exports = function(angel){
   angel.on("help", function(angel, next){
     var $handlers = angel.reactor.$handlers
     var table = new Table({
-      head: ['Command pattern', 'Example']
+      head: ['Command pattern', 'Example', 'Description']
     });
     for(var i = 0; i<$handlers.length; i++) {
       var helpText = {}
       var originalPattern = $handlers[i].originalPattern
-      helpText[originalPattern] = $handlers[i].example || "example missing"
+      helpText[originalPattern] = [$handlers[i].example || "example missing", $handlers[i].description || "description missing"]
       table.push(helpText)
     }
     console.log(table.toString())
@@ -22,13 +22,13 @@ module.exports = function(angel){
   angel.on(/help (.*)$/, function(angel, next){
     var $handlers = angel.reactor.$handlers
     var table = new Table({
-      head: ['Command pattern', 'Example']
+      head: ['Command pattern', 'Example', 'Description']
     });
     for(var i = 0; i<$handlers.length; i++)  {
       if($handlers[i].originalPattern.toString().match(angel.cmdData[1])) {
         var helpText = {}
         var originalPattern = $handlers[i].originalPattern
-        helpText[originalPattern] = $handlers[i].example || "example missing"
+        helpText[originalPattern] = [$handlers[i].example || "example missing", $handlers[i].description || "description missing"]
         table.push(helpText)
       }
     }

--- a/index.js
+++ b/index.js
@@ -17,6 +17,13 @@ var tableOpts = {
   ],
   wordWrap: true
 }
+var getTableRow = function (command, example, description) {
+  return [
+    { vAlign: 'center', content: command ? command.toString() : "missing command" },
+    { vAlign: 'center', content: example ? example.toString() : "missing example" },
+    { vAlign: 'top', content: description ? description.toString()  : "missing description" },
+  ]
+}
 
 module.exports = function(angel){
   angel.on("help", function(angel, next){
@@ -24,12 +31,11 @@ module.exports = function(angel){
     var table = new Table(tableOpts);
     for(var i = 0; i<$handlers.length; i++) {
       var originalPattern = $handlers[i].originalPattern
-      var helpText = [
+      table.push(getTableRow(
         originalPattern,
-        $handlers[i].example || "example missing",
-        $handlers[i].description || "description missing"
-      ]
-      table.push(helpText)
+        $handlers[i].example,
+        $handlers[i].description
+      ))
     }
     console.log(table.toString())
     next(null, table)
@@ -43,12 +49,11 @@ module.exports = function(angel){
     for(var i = 0; i<$handlers.length; i++)  {
       if($handlers[i].originalPattern.toString().match(angel.cmdData[1])) {
         var originalPattern = $handlers[i].originalPattern
-        var helpText = [
+        table.push(getTableRow(
           originalPattern,
-          $handlers[i].example || "example missing",
-          $handlers[i].description || "description missing"
-        ]
-        table.push(helpText)
+          $handlers[i].example,
+          $handlers[i].description
+        ))
       }
     }
     console.log(table.toString())

--- a/index.js
+++ b/index.js
@@ -1,16 +1,34 @@
-var Table = require("cli-table")
+var Table = require("cli-table2")
 var _ = require("underscore")
+var getWidthPercentage = function (percentage) {
+  var terminalWidth = process.stdout.columns || 100
+  return Math.floor(terminalWidth * percentage / 100) - 1
+}
+var tableOpts = {
+  head: ['Command pattern', 'Example', 'Description'],
+  style: {
+    head: [], // disable colors in header cells
+    border: [] // disable colors for the border
+  },
+  colWidths: [
+    getWidthPercentage(30),
+    getWidthPercentage(30),
+    getWidthPercentage(40)
+  ],
+  wordWrap: true
+}
 
 module.exports = function(angel){
   angel.on("help", function(angel, next){
     var $handlers = angel.reactor.$handlers
-    var table = new Table({
-      head: ['Command pattern', 'Example', 'Description']
-    });
+    var table = new Table(tableOpts);
     for(var i = 0; i<$handlers.length; i++) {
-      var helpText = {}
       var originalPattern = $handlers[i].originalPattern
-      helpText[originalPattern] = [$handlers[i].example || "example missing", $handlers[i].description || "description missing"]
+      var helpText = [
+        originalPattern,
+        $handlers[i].example || "example missing",
+        $handlers[i].description || "description missing"
+      ]
       table.push(helpText)
     }
     console.log(table.toString())
@@ -21,14 +39,15 @@ module.exports = function(angel){
 
   angel.on(/help (.*)$/, function(angel, next){
     var $handlers = angel.reactor.$handlers
-    var table = new Table({
-      head: ['Command pattern', 'Example', 'Description']
-    });
+    var table = new Table(tableOpts);
     for(var i = 0; i<$handlers.length; i++)  {
       if($handlers[i].originalPattern.toString().match(angel.cmdData[1])) {
-        var helpText = {}
         var originalPattern = $handlers[i].originalPattern
-        helpText[originalPattern] = [$handlers[i].example || "example missing", $handlers[i].description || "description missing"]
+        var helpText = [
+          originalPattern,
+          $handlers[i].example || "example missing",
+          $handlers[i].description || "description missing"
+        ]
         table.push(helpText)
       }
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "underscore": "1.5.2",
-    "cli-table": "0.3.1"
+    "cli-table2": "0.2.0"
   },
   "devDependencies": {
     "jasmine-node": "~1.11.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "underscore": "1.5.2",
-    "cli-table": "0.2.0"
+    "cli-table": "0.3.1"
   },
   "devDependencies": {
     "jasmine-node": "~1.11.0",


### PR DESCRIPTION
This PR brings some cosmetic improvements to the tables printed by this module:

- The `Desccription` column has been added, taking the text from `.description('some description')` of the angel commands
- The `cli-table` dep has been swapped for `cli-table2` because it is more powerful / fixes some conceptual issues.
- Outputted tabled are now responsive in regards to the terminal width (amount of characters that can be printed on one line).
- If the text in a single table cell exceed its length it is wrapped on the next line (rather than being trimmed down).
- The `Command` and `Example` cell contents are center aligned, while the `Description` cell contents are top aligned.